### PR TITLE
rebuild against looser abseil

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0001-disable-libraries.patch
 
 build:
-  number: 0
+  number: 1
 requirements:
   build:
     - {{ compiler('c') }}


### PR DESCRIPTION
Trying to fix errors now that we have abseil 20230125.2, which conflicts with previous run-exports of ".0" despite https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/453