### PR TITLE
fix: remove `bigquery` from Windows build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,7 +16,7 @@ set DISABLED=%DISABLED%,-pubsub
 set DISABLED=%DISABLED%,-spanner
 set DISABLED=%DISABLED%,-storage
 :: `bigquery` is provided by `google-cloud-cpp-bigquery-feedstock`.
-set DISABLED=%DISABLED%,-compute
+set DISABLED=%DISABLED%,-bigquery
 :: `compute` is provided by `google-cloud-cpp-compute-feedstock`.
 set DISABLED=%DISABLED%,-compute
 :: `aiplatform` and friends are be provided by `google-cloud-cpp-ai-feedstock`.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-Backport-12911-from-upstream.patch
 
 build:
-  number: 6
+  number: 7
 requirements:
   build:
     - {{ compiler('c') }}


### PR DESCRIPTION

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
